### PR TITLE
Revert "chore(api): use different URL (temporarily)"

### DIFF
--- a/apollos-church-api/config.yml
+++ b/apollos-church-api/config.yml
@@ -24,7 +24,7 @@ BUGSNAG:
   ## Optional, but you'll need to remove references to @apollosproject/bugsnag if you don't wish to use.
   API_KEY: d936777e50cddda8a3e4387ae65da09f
 ROCK:
-  URL: https://apollos2rock.lcbcchurch.com
+  URL: https://origin.lcbcchurch.com
   API_TOKEN: ${ROCK_TOKEN}
   SHARE_URL: https://lcbcchurch.com
   # This should match the timezone of the Rock server


### PR DESCRIPTION
Reverts lcbc-digital/ephesus#39

We can use this PR to debug why logins are broken when pointed at `origin.lcbcchurch.com`