### PR TITLE
fix: samsung crash fix

### DIFF
--- a/apolloschurchapp/android/app/src/main/java/com/bluebridgechurches/lcbc/MainActivity.java
+++ b/apolloschurchapp/android/app/src/main/java/com/bluebridgechurches/lcbc/MainActivity.java
@@ -31,4 +31,9 @@ public class MainActivity extends ReactActivity {
         }
       };
     }
+
+    @Override
+      protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(null);
+}
 }

--- a/apolloschurchapp/android/app/src/main/java/com/bluebridgechurches/lcbc/MainActivity.java
+++ b/apolloschurchapp/android/app/src/main/java/com/bluebridgechurches/lcbc/MainActivity.java
@@ -19,7 +19,7 @@ public class MainActivity extends ReactActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         SplashScreen.show(this, R.style.SplashScreenTheme);
-        super.onCreate(savedInstanceState);
+        super.onCreate(null);
     }
 
     @Override
@@ -31,9 +31,4 @@ public class MainActivity extends ReactActivity {
         }
       };
     }
-
-    @Override
-      protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(null);
-}
 }


### PR DESCRIPTION
We are getting reports on Android (samsung devices) of nondeterministic crashes. @vinnyjth HMW we test this fix since we are unable to replicate on sim (or at least I have been unable to replicate it)? Or does this seem like a fix we can push out into the wild?

Fix located [here](https://github.com/software-mansion/react-native-screens/issues/17#issuecomment-424704067)